### PR TITLE
fix: add MongoDB URI to production deployment environment

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -40,7 +40,7 @@ jobs:
       env:
         NODE_ENV: test
         CI: true
-        MONGODB_URI: ${{ secrets.MONGODB_URI }}  # ← Agregar esta línea
+        MONGODB_URI: ${{ secrets.MONGODB_URI }}
       run: |
         npm test -- --forceExit
     
@@ -101,7 +101,7 @@ jobs:
           --memory 512Mi \
           --cpu 1 \
           --max-instances 10 \
-          --set-env-vars="ENVIRONMENT=production,NODE_ENV=production"
+          --set-env-vars="ENVIRONMENT=production,NODE_ENV=production,MONGODB_URI=${{ secrets.MONGODB_URI }}"
     
     - name: Get service URL
       run: |


### PR DESCRIPTION
- Add MONGODB_URI environment variable to Cloud Run deployment
- Configure database connection for production environment